### PR TITLE
Make HitBox.Reset() accessible for TestCharacter

### DIFF
--- a/Assets/UnityPlatformer/Scripts/Characters/Health/HitBox.cs
+++ b/Assets/UnityPlatformer/Scripts/Characters/Health/HitBox.cs
@@ -105,7 +105,7 @@ namespace UnityPlatformer {
     /// <summary>
     /// Set layer to Configuration.ropesMask
     /// </summary>
-    void Reset() {
+    public void Reset() {
       if (characterState == null) {
         characterState = new CharacterStatesCheck();
       }


### PR DESCRIPTION
With Unity 5.5.2f1, there is an error that says "Reset() is inaccessible to TestCharacter due to its protection level", this fixes that by making it public.